### PR TITLE
Fix Authorization header bug

### DIFF
--- a/projects/savvato-javascript-services/src/lib/_services/api/api.service.spec.ts
+++ b/projects/savvato-javascript-services/src/lib/_services/api/api.service.spec.ts
@@ -1,16 +1,29 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { JWTApiService } from './api.service';
+import { AuthService } from '../auth/auth.service';
 
 describe('ApiService', () => {
   let service: JWTApiService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        JWTApiService,
+        { provide: AuthService, useValue: { getToken: () => 'test-token' } }
+      ]
+    });
     service = TestBed.inject(JWTApiService);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should include Authorization header when auth flag is true', () => {
+    const headers = service.getHeaders();
+    expect(headers.get('Authorization')).toBe('Bearer test-token');
   });
 });

--- a/projects/savvato-javascript-services/src/lib/_services/api/api.service.ts
+++ b/projects/savvato-javascript-services/src/lib/_services/api/api.service.ts
@@ -21,7 +21,7 @@ export class JWTApiService {
       .set('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
 
     if (auth)
-      rtn.set("Authorization", "Bearer " + this._authService.getToken());
+      rtn = rtn.set("Authorization", "Bearer " + this._authService.getToken());
 
     return rtn;
   }

--- a/projects/savvato-javascript-services/src/lib/_services/storage/storage.service.spec.ts
+++ b/projects/savvato-javascript-services/src/lib/_services/storage/storage.service.spec.ts
@@ -1,12 +1,22 @@
 import { TestBed } from '@angular/core/testing';
 
 import { StorageService } from './storage.service';
+import { StorageKey } from './storage.model';
 
 describe('StorageService', () => {
-    beforeEach(() => TestBed.configureTestingModule({}));
+    let service: StorageService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({});
+        service = TestBed.inject(StorageService);
+        localStorage.clear();
+    });
 
     it('should be created', () => {
-        const service: StorageService = TestBed.get(StorageService);
         expect(service).toBeTruthy();
+    });
+
+    it('should return null when key not present', () => {
+        expect(service.read(StorageKey.AUTH_TOKEN)).toBeNull();
     });
 });

--- a/projects/savvato-javascript-services/src/lib/_services/storage/storage.service.ts
+++ b/projects/savvato-javascript-services/src/lib/_services/storage/storage.service.ts
@@ -17,7 +17,8 @@ export class StorageService {
     }
 
     public read(key: StorageKey): any {
-        return JSON.parse(this.storage.getItem(key)!);
+        const item = this.storage.getItem(key);
+        return item ? JSON.parse(item) : null;
     }
 
     public remove(key: StorageKey) {


### PR DESCRIPTION
## Summary
- fix missing Authorization header in JWTApiService
- ensure JWTApiService unit test verifies Authorization header
- handle missing localStorage values gracefully
- add a unit test for reading nonexistent storage keys

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ec90d4b883219ce84915f39cc2e7